### PR TITLE
Add Magento 2 source to newsletter subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [4.0.810 - 2023-01-09
+### Fixed
+- Fixed an issue where the `Source` property was not being sent with newsletter subscriptions to a list from Magento 2.
+
 ### [4.0.9] - 2023-01-03
 ### Changed
 - Updated default SMS consent language
@@ -202,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSP now uses report-only mode
 
 
-[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.9...HEAD
+[Unreleased]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.10...HEAD
+[4.0.10]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.9...4.0.10
 [4.0.9]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.8...4.0.9
 [4.0.8]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.7...4.0.8
 [4.0.7]: https://github.com/klaviyo/magento2-klaviyo/compare/4.0.6...4.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-### [4.0.810 - 2023-01-09
+### [4.0.10 - 2023-01-09
 ### Fixed
 - Fixed an issue where the `Source` property was not being sent with newsletter subscriptions to a list from Magento 2.
 

--- a/Observer/NewsletterSubscribeObserver.php
+++ b/Observer/NewsletterSubscribeObserver.php
@@ -14,6 +14,8 @@ use Magento\Newsletter\Model\Subscriber;
 
 class NewsletterSubscribeObserver implements ObserverInterface
 {
+    private const SOURCE_ID_MAGENTO2 = '-56';
+    
     /**
      * @var Data
      */
@@ -52,7 +54,8 @@ class NewsletterSubscribeObserver implements ObserverInterface
                 $this->helper->subscribeEmailToKlaviyoList(
                     $customer ? $customer->getEmail() : $subscriber->getEmail(),
                     $customer ? $customer->getFirstname() : $subscriber->getFirstname(),
-                    $customer ? $customer->getLastname() : $subscriber->getLastname()
+                    $customer ? $customer->getLastname() : $subscriber->getLastname(),
+                    self::SOURCE_ID_MAGENTO2
                 );
             } else {
                 $this->helper->unsubscribeEmailFromKlaviyoList(

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klaviyo/magento2-extension",
     "description": "Klaviyo extension for Magento 2. Allows pushing newsletters to Klaviyo's platform and more.",
     "type": "magento2-module",
-    "version": "4.0.9",
+    "version": "4.0.10",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Klaviyo_Reclaim" setup_version="4.0.9" schema_version="4.0.9">
+  <module name="Klaviyo_Reclaim" setup_version="4.0.10" schema_version="4.0.10"> <!-- These versions are not needed anymore, but some patches might need to be refactored to remove -->
       <sequence>
           <module name="Magento_Customer"/>
           <module name="Magento_Checkout"/>


### PR DESCRIPTION
## Description
Bug fix for the source property not being passed with newsletter subscription additions to a list.


## Manual Testing Steps
1. Ensure you have "Consent at Checkout > Subscribe contacts to email marketing at checkout" enabled
2. Ensure the [source value for Magento 2](https://help.klaviyo.com/hc/en-us/articles/1260804673530-Source-Value-Reference#-source-value-reference-2) is passed as `Source` with the API call made so that subscriber is confirmed/attributed from Magento 2.

## Pre-Submission Checklist:

- [x] You've updated the CHANGELOG following the steps [here](https://github.com/klaviyo/magento2-klaviyo#making-updates)
- [ ] **Internal Only** - If this is a release, have you:
  - [ ] Updated the links in the CHANGELOG to point towards the new versions
  - [ ] Incremented the version in the following places: module.xml and composer.json